### PR TITLE
Disable the nullable type rule

### DIFF
--- a/src/Load.php
+++ b/src/Load.php
@@ -39,6 +39,7 @@ final class Load
                 'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
                 'no_superfluous_phpdoc_tags' => true,
                 'no_trailing_whitespace_in_string' => false,
+                'nullable_type_declaration_for_default_null_value' => false,
                 'phpdoc_separation' => false,
                 'no_useless_else' => true,
                 'no_useless_return' => true,

--- a/tests/AllRulesTest.php
+++ b/tests/AllRulesTest.php
@@ -36,14 +36,14 @@ final class AllRulesTest extends TestCase
         self::assertCount(1, $json['files']);
 
         $diff = $json['files'][0]['diff'];
-        $diff = $this->removeFilePath(self::FILE, $diff);
+        $diff = $this->removeFilePath($diff);
 
         self::assertSame(file_get_contents(__DIR__ . '/Files/expected.diff'), $diff);
     }
 
-    private function removeFilePath(string $filePath, string $diff): string
+    private function removeFilePath(string $diff): string
     {
-        return str_replace($filePath, '__FILE__', $diff);
+        return str_replace(self::FILE, '__FILE__', $diff);
     }
 
     private function executeFixCommand(): string

--- a/tests/Files/AReallyBadFile.php
+++ b/tests/Files/AReallyBadFile.php
@@ -14,4 +14,5 @@ private function bla(){
     if ($this->string == '') return 'Heyo!';
 return 'hi!';
 }
+public function whoop(?string $string = null, int|null $int = null): void {}
 }

--- a/tests/Files/expected.diff
+++ b/tests/Files/expected.diff
@@ -1,6 +1,6 @@
 --- __FILE__
 +++ __FILE__
-@@ -1,17 +1,41 @@
+@@ -1,18 +1,45 @@
 -<?php declare(strict_types=1);
 +<?php
 +
@@ -47,6 +47,10 @@
 +
 +        return 'hi!';
 +    }
++
++    public function whoop(?string $string = null, int|null $int = null): void
++    {
++    }
  }
 -private function ifsAreWrappedAndUselessElseIsRemoved():bool{if (true) return true; else return false;
 -//There's currently a bug that causes the second return statement to be incorrectly aligned for some reason.
@@ -56,5 +60,6 @@
 -    if ($this->string == '') return 'Heyo!';
 -return 'hi!';
 -}
+-public function whoop(?string $string = null, int|null $int = null): void {}
 -}
 \ No newline at end of file


### PR DESCRIPTION
With this rule enabled, this:
```php
    public function example(
       ?string $string = null,
    ) {}
```
    
Turns into this:
```php
    public function example(
       string $string = null,
    ) {}
```
Which is not something we want.
