### PR TITLE
Enable no_trailing_whitespace_in_string rule

### DIFF
--- a/src/Load.php
+++ b/src/Load.php
@@ -38,7 +38,7 @@ final class Load
                 'concat_space' => ['spacing' => 'one'],
                 'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
                 'no_superfluous_phpdoc_tags' => true,
-                'no_trailing_whitespace_in_string' => false,
+                'no_trailing_whitespace_in_string' => true,
                 'nullable_type_declaration_for_default_null_value' => false,
                 'phpdoc_separation' => false,
                 'no_useless_else' => true,

--- a/tests/Files/AReallyBadFile.php
+++ b/tests/Files/AReallyBadFile.php
@@ -4,7 +4,7 @@ class AReallyBadFile {
 protected string $string='';
 public function __construct(Foo $a, Bar $bar){}
 public function getMethod():string{
-return $this->string;
+return $this->string;   
 }
 private function ifsAreWrappedAndUselessElseIsRemoved():bool{if (true) return true; else return false;
 //There's currently a bug that causes the second return statement to be incorrectly aligned for some reason.
@@ -15,4 +15,10 @@ private function bla(){
 return 'hi!';
 }
 public function whoop(?string $string = null, int|null $int = null): void {}
+
+public function query(): void {
+    <<<QUERY
+                SELECT COUNT(*) 
+    QUERY;
+}
 }

--- a/tests/Files/expected.diff
+++ b/tests/Files/expected.diff
@@ -1,6 +1,6 @@
 --- __FILE__
 +++ __FILE__
-@@ -1,18 +1,45 @@
+@@ -1,24 +1,52 @@
 -<?php declare(strict_types=1);
 +<?php
 +
@@ -11,8 +11,22 @@
 -protected string $string='';
 -public function __construct(Foo $a, Bar $bar){}
 -public function getMethod():string{
--return $this->string;
-+
+-return $this->string;   
+-}
+-private function ifsAreWrappedAndUselessElseIsRemoved():bool{if (true) return true; else return false;
+-//There's currently a bug that causes the second return statement to be incorrectly aligned for some reason.
+-//This doesn't happen when you run the fixer on multiple files...
+-}
+-private function bla(){
+-    if ($this->string == '') return 'Heyo!';
+-return 'hi!';
+-}
+-public function whoop(?string $string = null, int|null $int = null): void {}
+ 
+-public function query(): void {
+-    <<<QUERY
+-                SELECT COUNT(*) 
+-    QUERY;
 +class AReallyBadFile
 +{
 +    protected string $string = '';
@@ -51,15 +65,13 @@
 +    public function whoop(?string $string = null, int|null $int = null): void
 +    {
 +    }
++
++    public function query(): void
++    {
++        <<<QUERY
++                        SELECT COUNT(*)
++            QUERY;
++    }
  }
--private function ifsAreWrappedAndUselessElseIsRemoved():bool{if (true) return true; else return false;
--//There's currently a bug that causes the second return statement to be incorrectly aligned for some reason.
--//This doesn't happen when you run the fixer on multiple files...
--}
--private function bla(){
--    if ($this->string == '') return 'Heyo!';
--return 'hi!';
--}
--public function whoop(?string $string = null, int|null $int = null): void {}
 -}
 \ No newline at end of file


### PR DESCRIPTION
Remove trailing whitespace from strings

This is so that we comply with PSR12

> There MUST NOT be trailing whitespace at the end of lines.