### PR TITLE
Enable nullable type declaration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,18 +12,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: 8.0
+          - php-version: 8.3
             composer-options: --prefer-lowest
-            name: PHP 8.0 with lowest requirements
-          - php-version: 8.0
+            name: PHP 8.3 with lowest requirements
+          - php-version: 8.3
             composer-options: --prefer-dist
-            name: PHP 8.0
-          - php-version: 8.1
+            name: PHP 8.3
+          - php-version: 8.4
             composer-options: --prefer-dist
-            name: PHP 8.1
-          - php-version: 8.2
-            composer-options: --prefer-dist
-            name: PHP 8.2
+            name: PHP 8.4
 
     name: Tests ${{ matrix.name }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ coding-standard:
 	vendor/bin/php-cs-fixer fix --verbose
 
 test:
-	vendor/bin/phpunit --verbose
+	vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.14"
+        "friendsofphp/php-cs-fixer": "^3.70"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "psr-4": { "Instapro\\CodingStandard\\Test\\": "tests"}
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.3",
         "friendsofphp/php-cs-fixer": "^3.70"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
         "friendsofphp/php-cs-fixer": "^3.70"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^12.2"
     }
 }

--- a/src/Load.php
+++ b/src/Load.php
@@ -39,7 +39,7 @@ final class Load
                 'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
                 'no_superfluous_phpdoc_tags' => true,
                 'no_trailing_whitespace_in_string' => true,
-                'nullable_type_declaration_for_default_null_value' => false,
+                'nullable_type_declaration_for_default_null_value' => true,
                 'phpdoc_separation' => false,
                 'no_useless_else' => true,
                 'no_useless_return' => true,

--- a/src/Load.php
+++ b/src/Load.php
@@ -14,7 +14,7 @@ final class Load
     {
         $constructorArgumentsOnNewLinesRule = new ConstructorArgumentsOnNewLinesRule();
 
-        return (new Config('Instapro'))
+        $config = (new Config('Instapro'))
             ->registerCustomFixers([$constructorArgumentsOnNewLinesRule])
             ->setRiskyAllowed(true)
             ->setRules([
@@ -86,5 +86,11 @@ final class Load
                 'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
             ])
             ->setFinder($finder);
+
+        if (method_exists($config, 'setUnsupportedPhpVersionAllowed')) {
+            $config = $config->setUnsupportedPhpVersionAllowed(true);
+        }
+
+        return $config;
     }
 }

--- a/tests/AllRulesTest.php
+++ b/tests/AllRulesTest.php
@@ -6,15 +6,16 @@ namespace Instapro\CodingStandard\Test;
 
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use const JSON_THROW_ON_ERROR;
 
 /**
  * @internal
- *
- * @large
  */
+#[Large]
 final class AllRulesTest extends TestCase
 {
     public const FILE = __DIR__ . '/Files/AReallyBadFile.php';
@@ -26,7 +27,7 @@ final class AllRulesTest extends TestCase
         $this->application = new Application();
     }
 
-    /** @test */
+    #[Test]
     public function it_formats_code_properly(): void
     {
         $output = $this->executeFixCommand();

--- a/tests/Files/AReallyBadFile.php
+++ b/tests/Files/AReallyBadFile.php
@@ -21,6 +21,8 @@ private function test(): void{
 }
 public function whoop(?string $string = null, int|null $int = null): void {}
 
+public function missingNullable(string $string = null, int $int = null): void {}
+
 public function query(): void {
     <<<QUERY
                 SELECT COUNT(*) 

--- a/tests/Files/expected.diff
+++ b/tests/Files/expected.diff
@@ -1,6 +1,6 @@
 --- __FILE__
 +++ __FILE__
-@@ -1,29 +1,59 @@
+@@ -1,31 +1,63 @@
 -<?php declare(strict_types=1);
 +<?php
 +
@@ -28,14 +28,15 @@
 -}
 -public function whoop(?string $string = null, int|null $int = null): void {}
  
+-public function missingNullable(string $string = null, int $int = null): void {}
++class AReallyBadFile
++{
++    protected string $string = '';
+ 
 -public function query(): void {
 -    <<<QUERY
 -                SELECT COUNT(*) 
 -    QUERY;
-+class AReallyBadFile
-+{
-+    protected string $string = '';
-+
 +    public function __construct(
 +        Foo $a,
 +        Bar $bar,
@@ -74,7 +75,11 @@
 +        };
 +    }
 +
-+    public function whoop(?string $string = null, int|null $int = null): void
++    public function whoop(?string $string = null, ?int $int = null): void
++    {
++    }
++
++    public function missingNullable(?string $string = null, ?int $int = null): void
 +    {
 +    }
 +

--- a/tests/Rule/ConstructorArgumentsOnNewLinesRuleTest.php
+++ b/tests/Rule/ConstructorArgumentsOnNewLinesRuleTest.php
@@ -7,12 +7,14 @@ namespace Instapro\CodingStandard\Test\Rule;
 use Instapro\CodingStandard\Rule\ConstructorArgumentsOnNewLinesRule;
 use Instapro\CodingStandard\Test\AbstractFixer;
 use PhpCsFixer\Fixer\FixerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
- *
- * @small
  */
+#[Small]
 final class ConstructorArgumentsOnNewLinesRuleTest extends AbstractFixer
 {
     protected function createFixer(): FixerInterface
@@ -20,10 +22,8 @@ final class ConstructorArgumentsOnNewLinesRuleTest extends AbstractFixer
         return new ConstructorArgumentsOnNewLinesRule();
     }
 
-    /**
-     * @test
-     * @dataProvider provideFixCases
-     */
+    #[Test]
+    #[DataProvider('provideFixCases')]
     public function it_formats_code_properly(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);


### PR DESCRIPTION
* **Update lowest supported version of cs fixer**
Version 3.14 is from 2023 so drop support for it in
favour of a newer version
* **Enable nullable_type_declaration_for_default_null_value rule**
In PHP8.4, implicitly nullable parameter types were deprecated:

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

Enabling the `nullable_type_declaration_for_default_null_value` rule
fixes this automatically for us
* **Update PHP Versions**
PHP 8.0 is no longer supported and PHP 8.1 and 8.2
are security fixes only so we can drop support for these
and only test using PHP versions with active support (8.3 and 8.4)
As `php-cs-fixer` doesn't yet support version 8.4 of PHP then we
need to set `setUnsupportedPhpVersionAllowed` as true to run on 8.4

* **Update PHPUnit to V12**