### PR TITLE
Enable parallel processing

### DIFF
--- a/src/Load.php
+++ b/src/Load.php
@@ -7,6 +7,7 @@ namespace Instapro\CodingStandard;
 use Instapro\CodingStandard\Rule\ConstructorArgumentsOnNewLinesRule;
 use PhpCsFixer\Config;
 use PhpCsFixer\ConfigInterface;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 final class Load
 {
@@ -86,6 +87,7 @@ final class Load
                 'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
             ])
             ->setFinder($finder)
+            ->setParallelConfig(ParallelConfigFactory::detect())
             ->setUnsupportedPhpVersionAllowed(true);
 
         return $config;


### PR DESCRIPTION
In order to speed up CS Fixer enable parallel processing so it can run on multiple cores

Fixes #10 