### PR TITLE
Ensure we always import the class names instead of using backslash

### DIFF
--- a/src/Load.php
+++ b/src/Load.php
@@ -53,6 +53,9 @@ final class Load
                     'sort_algorithm' => 'alpha',
                     'imports_order' => ['class', 'function', 'const'],
                 ],
+                'fully_qualified_strict_types' => [
+                    'import_symbols' => true,
+                ],
                 'phpdoc_order' => true,
                 'array_syntax' => ['syntax' => 'short'],
                 'echo_tag_syntax' => [

--- a/tests/Files/AReallyBadFile.php
+++ b/tests/Files/AReallyBadFile.php
@@ -2,7 +2,7 @@
 namespace Instapro;
 class AReallyBadFile {
 protected string $string='';
-public function __construct(Foo $a, Bar $bar){}
+public function __construct(Foo $a, \Baz\Bar $bar){}
 public function getMethod():string{
 return $this->string;   
 }

--- a/tests/Files/expected.diff
+++ b/tests/Files/expected.diff
@@ -1,6 +1,6 @@
 --- __FILE__
 +++ __FILE__
-@@ -1,31 +1,63 @@
+@@ -1,31 +1,65 @@
 -<?php declare(strict_types=1);
 +<?php
 +
@@ -9,7 +9,7 @@
  namespace Instapro;
 -class AReallyBadFile {
 -protected string $string='';
--public function __construct(Foo $a, Bar $bar){}
+-public function __construct(Foo $a, \Baz\Bar $bar){}
 -public function getMethod():string{
 -return $this->string;   
 -}
@@ -29,14 +29,16 @@
 -public function whoop(?string $string = null, int|null $int = null): void {}
  
 -public function missingNullable(string $string = null, int $int = null): void {}
-+class AReallyBadFile
-+{
-+    protected string $string = '';
++use Baz\Bar;
  
 -public function query(): void {
 -    <<<QUERY
 -                SELECT COUNT(*) 
 -    QUERY;
++class AReallyBadFile
++{
++    protected string $string = '';
++
 +    public function __construct(
 +        Foo $a,
 +        Bar $bar,


### PR DESCRIPTION
We're already using this rule, but there isn't yet a way to check this. This commit introduces that check.